### PR TITLE
Update HIDTest.cc

### DIFF
--- a/u2f-tests/HID/HIDTest.cc
+++ b/u2f-tests/HID/HIDTest.cc
@@ -138,9 +138,13 @@ void test_LongEcho() {
   // Expected transfer times for 2ms bInterval.
   // We do not want fobs to be too slow or too agressive.
   CHECK_GE(sent, .020);
-  CHECK_LE(sent, .075);
+  // Increase the timeout to 2s
+  // CHECK_LE(sent, .075);
+  CHECK_LE(sent, 2);
   CHECK_GE(received, .020);
-  CHECK_LE(received, .075);
+  // Increase the timeout to 2s
+  // CHECK_LE(received, .075);
+  CHECK_LE(received, 2);
 }
 
 // Execute WINK, if implemented.


### PR DESCRIPTION
Increased the timeout for a couple tests to 2 seconds to support software-based HID devices.