### PR TITLE
Update U2FTest.cc

### DIFF
--- a/u2f-tests/HID/U2FTest.cc
+++ b/u2f-tests/HID/U2FTest.cc
@@ -370,8 +370,8 @@ int main(int argc, char* argv[]) {
   uint32_t ctr2;
   PASS(ctr2 = test_Sign(0x9000));
 
-  // Ctr should have incremented by 1.
-  CHECK_EQ(ctr2, ctr1 + 1);
+  // Ctr should have incremented.
+  CHECK_GT(ctr2, ctr1);
 
   U2Fob_destroy(device);
   return 0;


### PR DESCRIPTION
As discussed at the plenary this morning, the compliance test requires the counter to be incremented by 1 on every sign attempt.
The spec only indicates that the counter should be incremented. RPs also do not / cannot check that the counter is incremented only by 1, since that is not practical.
Our proposal is to therefore update the test to check that ctr2 > ctr1: