### PR TITLE
Update HIDTest.cc

### DIFF
--- a/u2f-tests/HID/HIDTest.cc
+++ b/u2f-tests/HID/HIDTest.cc
@@ -28,6 +28,7 @@ using namespace std;
 int arg_Verbose = 0;  // default
 bool arg_Pause = false;  // default
 bool arg_Abort = true;  // default
+bool arg_VirtualDevice = false;
 
 static
 void checkPause() {
@@ -137,10 +138,12 @@ void test_LongEcho() {
 
   // Expected transfer times for 2ms bInterval.
   // We do not want fobs to be too slow or too agressive.
-  CHECK_GE(sent, .020);
-  CHECK_LE(sent, .075);
-  CHECK_GE(received, .020);
-  CHECK_LE(received, .075);
+  if (!arg_VirtualDevice) {
+    CHECK_GE(sent, .020);
+    CHECK_LE(sent, .075);
+    CHECK_GE(received, .020);
+    CHECK_LE(received, .075);
+  }
 }
 
 // Execute WINK, if implemented.
@@ -575,7 +578,7 @@ void test_Descriptor() {
 int main(int argc, char* argv[]) {
   if (argc < 2) {
     cerr << "Usage: " << argv[0]
-         << " <device-path> [-a] [-v] [-V] [-p]" << endl;
+         << " <device-path> [-a] [-v] [-V] [-p] [-d]" << endl;
     return -1;
   }
 
@@ -601,6 +604,10 @@ int main(int argc, char* argv[]) {
       // Pause at abort
       arg_Pause = true;
     }
+    if (!strncmp(argv[argc], "-d", 2)) {
+		  // Virtual Device or Software based authenticators.
+		  arg_VirtualDevice = true;
+	  }
   }
 
   srand((unsigned int) time(NULL));

--- a/u2f-tests/HID/HIDTest.cc
+++ b/u2f-tests/HID/HIDTest.cc
@@ -605,7 +605,7 @@ int main(int argc, char* argv[]) {
       arg_Pause = true;
     }
     if (!strncmp(argv[argc], "-d", 2)) {
-		  // Virtual Device or Software based authenticators.
+		  // Virtual Device (Driver).
 		  arg_VirtualDevice = true;
 	  }
   }


### PR DESCRIPTION
Added flag to differentiate between external usb devices and internal/virtual devices. This is to account for differences in device implementation that do not affect interop or U2F functionality.

As of now there is one check that is skipped for internal/virtual devices that have to rely on polling for the HID/USB transport.

Proposed changes:
1. New command-line param [-d] should be passed when the test is run on internal/virtual devices.
2. When -d option is provided, the check for time taken in testLong_echo is skipped.
